### PR TITLE
feat: use git url. use ABCTL_VERSION const.

### DIFF
--- a/Formula/abctl.rb
+++ b/Formula/abctl.rb
@@ -1,8 +1,11 @@
 class Abctl < Formula
+  ABCTL_VERSION = "v0.13.1".freeze
+
   desc "Airbyte's command-line tool for running Airbyte locally"
   homepage "https://github.com/airbytehq/abctl"
-  url "https://github.com/airbytehq/abctl/archive/refs/tags/v0.13.1.tar.gz"
-  sha256 "e01a6fb8ab83fb787ad5cdc0b46e58eebcda64f4aefd6068d782ffcf308ac631"
+  url "https://github.com/airbytehq/abctl.git",
+      tag: ABCTL_VERSION
+
   license "MIT"
 
   livecheck do
@@ -13,12 +16,12 @@ class Abctl < Formula
   depends_on "go" => :build
 
   def install
-    ENV["ABCTL_VERSION"] = "v0.13.1"
+    ENV["ABCTL_VERSION"] = ABCTL_VERSION
     system "make", "build"
     bin.install "build/abctl"
   end
 
   test do
-    assert_match "version: v0.13.1", shell_output("#{bin}/abctl version").strip
+    assert_equal "version: #{ABCTL_VERSION}", shell_output("#{bin}/abctl version").lines[0].strip
   end
 end


### PR DESCRIPTION
Prep for https://github.com/airbytehq/airbyte-internal-issues/issues/9450

- Use a `git` URL + tag name, which should be easier to update automatically from a workflow
- Improve the test – I had a passing test that was actually broken because `assert_match` was matching the leading `version: ` (with an empty version string)
- Move the version to a constant for each find/replace from a workflow (via `sed`)